### PR TITLE
Status

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
+/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 19:12:06 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/17 12:03:32 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/04/18 14:39:21 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,7 @@ int	process_input(char *input, t_shell *shell)
 		return (SUCCESS);
 	if (shell->tokens == NULL || parse(shell) != SUCCESS)
 		return (ERROR);
-	g_signal_status = execute_commands(shell);
+	shell->exit_status = execute_commands(shell);
 	last_arg = get_last_argument(shell->commands);
 	if (last_arg)
 	{
@@ -75,13 +75,15 @@ int	process_input(char *input, t_shell *shell)
 		update_env_array(shell);
 		free(last_arg);
 	}
-	return (g_signal_status);
+	return (shell->exit_status);
 }
 
 static int	shell_loop(t_shell *shell)
 {
 	char	*input;
+	int		status;
 
+	status = 0;
 	while (shell->running)
 	{
 		setup_signals();
@@ -90,15 +92,16 @@ static int	shell_loop(t_shell *shell)
 		{
 			printf("exit\n");
 			break ;
-		}		
-		g_signal_status = process_input(input, shell);
+		}
+		shell->exit_status = process_input(input, shell);
+		status = shell->exit_status;
 		free_tokens(shell->tokens);
 		shell->tokens = NULL;
 		free_commands(shell->commands);
 		shell->commands = NULL;
 		free(input);
 	}
-	return (g_signal_status);
+	return (status);
 }
 
 int	main(int argc, char **argv, char **envp)

--- a/srcs/parser/env.c
+++ b/srcs/parser/env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 21:24:50 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/16 17:53:36 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/18 16:50:44 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ static int	handle_special(char *input, int *i, char **result, t_shell *shell)
 {
 	if (input[*i] == '?')
 	{
-		input = ft_itoa(g_signal_status);
+		input = ft_itoa(shell->exit_status);
 		if (input == NULL)
 			return (ERROR);
 		join_result_free(result, input);

--- a/srcs/signals/signals.c
+++ b/srcs/signals/signals.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signals.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yabukirento <yabukirento@student.42.fr>    +#+  +:+       +#+        */
+/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 13:52:21 by ryabuki           #+#    #+#             */
-/*   Updated: 2025/04/16 14:54:11 by yabukirento      ###   ########.fr       */
+/*   Updated: 2025/04/18 14:33:33 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 void	handle_sigint(int sig)
 {
 	(void)sig;
-	g_signal_status = 130;
+	g_signal_status = SIGINT;
 	write(STDOUT_FILENO, "\n", 1);
 	rl_replace_line("", 0);
 	rl_on_new_line();


### PR DESCRIPTION
This pull request includes updates to improve the handling of exit statuses in the shell and standardizes author information in file headers. The most significant changes involve replacing the global `g_signal_status` variable with a `shell->exit_status` member for better encapsulation and modifying signal handling to use standard signal constants.

### Exit Status Handling Improvements:
* [`srcs/main.c`](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L70-R86): Replaced the global `g_signal_status` variable with `shell->exit_status` in `process_input` and `shell_loop` functions to encapsulate exit status within the `t_shell` structure. [[1]](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L70-R86) [[2]](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L94-R104)
* [`srcs/parser/env.c`](diffhunk://#diff-a8d73de4150ea70d92590cae32dd6673eb938e9bf422b67b18b813ec9e0804c6L29-R29): Updated `handle_special` to use `shell->exit_status` instead of `g_signal_status` when processing the `?` special character.

### Signal Handling Updates:
* [`srcs/signals/signals.c`](diffhunk://#diff-077ba7d0022629545541fbe5f844a2d69f8098d8d4890d4f1e77955caff7ff3aL18-R18): Modified `handle_sigint` to set `g_signal_status` to the standard `SIGINT` constant instead of a hardcoded value (130).

### File Header Updates:
* Updated author information in the headers of `srcs/main.c`, `srcs/parser/env.c`, and `srcs/signals/signals.c` to reflect the new author `myokono`. [[1]](diffhunk://#diff-4df2027984e76b7fa6b2f2bcbdd95ba572cf926771e7c5cd68b3d7747ab782c5L6-R9) [[2]](diffhunk://#diff-a8d73de4150ea70d92590cae32dd6673eb938e9bf422b67b18b813ec9e0804c6L6-R9) [[3]](diffhunk://#diff-077ba7d0022629545541fbe5f844a2d69f8098d8d4890d4f1e77955caff7ff3aL6-R9)